### PR TITLE
バックエンドとの通信において、Timezone を UTC に直してから送るようにする

### DIFF
--- a/src/lib/api/dtos/event.ts
+++ b/src/lib/api/dtos/event.ts
@@ -3,8 +3,9 @@ interface Event {
   location: string | null;
   start: string;
   end: string;
-  recurrence_list: string[];
   is_all_day: boolean;
+  recurrence_list: string[];
+  timezone: string;
 }
 
 export interface CreateEventRequest {

--- a/src/lib/utils/rfc5545.ts
+++ b/src/lib/utils/rfc5545.ts
@@ -1,18 +1,7 @@
-import { RRule, datetime } from "rrule";
+import { RRule } from "rrule";
 
 export const parseRecurrence = (recurrences: string[]): RRule | null => {
   if (recurrences.length === 0) return null;
   const rfcString = recurrences.join("\n");
   return RRule.fromString(rfcString);
-};
-
-export const toDatetime = (date: Date): Date => {
-  return datetime(
-    date.getFullYear(),
-    date.getMonth() + 1,
-    date.getDate(),
-    date.getHours(),
-    date.getMinutes(),
-    date.getSeconds(),
-  );
 };

--- a/src/lib/utils/timezone.ts
+++ b/src/lib/utils/timezone.ts
@@ -1,0 +1,13 @@
+import { TZDateMini } from "@date-fns/tz";
+
+export const applyTimezone = (date: Date, srcTz: string, dstTz: string): Date => {
+  if (srcTz === dstTz) return date;
+  return new TZDateMini(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    date.getHours(),
+    date.getMinutes(),
+    srcTz,
+  ).withTimeZone(dstTz);
+};


### PR DESCRIPTION
関数内では Event のタイムゾーンに直してから Date を引き回す（Validation などをやりやすくするため）